### PR TITLE
[Feat/#15] 홈 화면에서 운동리스트 화면 이동 구현하기

### DIFF
--- a/PlanFit/PlanFit/App/SceneDelegate.swift
+++ b/PlanFit/PlanFit/App/SceneDelegate.swift
@@ -18,7 +18,9 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     ) {
         guard let windowScene = (scene as? UIWindowScene) else { return }
         window = UIWindow(windowScene: windowScene)
-        window?.rootViewController = ViewController()
+        let navigationController = UINavigationController(rootViewController: HomeTabBarController())
+        navigationController.navigationBar.isHidden = true
+        window?.rootViewController = navigationController
         window?.makeKeyAndVisible()
     }
 

--- a/PlanFit/PlanFit/Presentation/Home/Controller/ExerciseViewController.swift
+++ b/PlanFit/PlanFit/Presentation/Home/Controller/ExerciseViewController.swift
@@ -7,6 +7,10 @@
 
 import UIKit
 
+protocol ExerciseNavigationDelegate: AnyObject {
+    func moveToWorkoutList()
+}
+
 final class ExerciseViewController: UIViewController {
     
     // MARK: - UIComponent
@@ -14,6 +18,8 @@ final class ExerciseViewController: UIViewController {
     private let rootView = ExerciseRootView()
     
     // MARK: - Property
+    
+    private weak var delegate: ExerciseNavigationDelegate?
     
     private var timeChoice = WorkoutTimeModel.normal {
         didSet {
@@ -25,6 +31,17 @@ final class ExerciseViewController: UIViewController {
         didSet {
             configureConditionDropDown(conditionChoice.value)
         }
+    }
+    
+    // MARK: - Initializer
+    
+    init(delegate: ExerciseNavigationDelegate) {
+        self.delegate = delegate
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     // MARK: - LifeCycle
@@ -67,9 +84,7 @@ final class ExerciseViewController: UIViewController {
     
     @objc
     private func startExerciseButtonDidTap(_ sender: UIButton) {
-        
-        // TODO: 다음 화면 (운동 리스트) 화면으로 넘어가기
-        
+        delegate?.moveToWorkoutList()
     }
 }
 

--- a/PlanFit/PlanFit/Presentation/Home/Controller/HomeTabBarController.swift
+++ b/PlanFit/PlanFit/Presentation/Home/Controller/HomeTabBarController.swift
@@ -18,6 +18,13 @@ final class HomeTabBarController: UITabBarController {
     }
 }
 
+extension HomeTabBarController: ExerciseNavigationDelegate {
+    func moveToWorkoutList() {
+        let viewController = WorkoutListViewController()
+        navigationController?.pushViewController(viewController, animated: true)
+    }
+}
+
 // MARK: - UISetting
 
 private extension HomeTabBarController {
@@ -40,7 +47,7 @@ private extension HomeTabBarController {
         ]
         
         let rootViewControllers = [
-            ExerciseViewController(),
+            ExerciseViewController(delegate: self),
             ViewController(),
             ViewController(),
             ViewController()
@@ -58,6 +65,9 @@ private extension HomeTabBarController {
             item.setTitleTextAttributes(attributes, for: .selected)
             
             viewController.tabBarItem = item
+            if viewController === ExerciseViewController.self {
+                return viewController
+            }
             return UINavigationController(rootViewController: viewController)
         }
     }

--- a/PlanFit/PlanFit/Presentation/Home/Controller/HomeTabBarController.swift
+++ b/PlanFit/PlanFit/Presentation/Home/Controller/HomeTabBarController.swift
@@ -18,6 +18,8 @@ final class HomeTabBarController: UITabBarController {
     }
 }
 
+// MARK: - ExerciseNavigationDelegate
+
 extension HomeTabBarController: ExerciseNavigationDelegate {
     func moveToWorkoutList() {
         let viewController = WorkoutListViewController()

--- a/PlanFit/PlanFit/Presentation/Home/View/ExerciseInfoBannerView.swift
+++ b/PlanFit/PlanFit/Presentation/Home/View/ExerciseInfoBannerView.swift
@@ -13,6 +13,8 @@ final class ExerciseInfoBannerView: UIView {
     
     // MARK: - UIComponent
     
+    let startExerciseButton = UIButton()
+    
     private let titleLabel = UILabel()
     
     private let explanationLabel = UILabel()
@@ -24,8 +26,6 @@ final class ExerciseInfoBannerView: UIView {
     private let caloriesItem = InfoItemView()
     
     private let infoItemStackView = UIStackView(axis: .horizontal)
-    
-    let startExerciseButton = UIButton()
     
     // MARK: - Initializer
     

--- a/PlanFit/PlanFit/Presentation/Home/View/StartExerciseBannerView.swift
+++ b/PlanFit/PlanFit/Presentation/Home/View/StartExerciseBannerView.swift
@@ -13,6 +13,10 @@ final class StartExerciseBannerView: UIView {
     
     // MARK: - UIComponent
     
+    let timeDropDownButton = DropDownButton()
+    
+    let conditionsDropDownButton = DropDownButton()
+    
     private let firstExplanationLabel = UILabel()
     
     private let sessionsDropDownButton = DropDownButton()
@@ -21,13 +25,9 @@ final class StartExerciseBannerView: UIView {
     
     private let firstContentStackView = UIStackView(axis: .horizontal)
     
-    let timeDropDownButton = DropDownButton()
-    
     private let thirdExplanationLabel = UILabel()
     
     private let secondContentStackView = UIStackView(axis: .horizontal)
-    
-    let conditionsDropDownButton = DropDownButton()
     
     private let lastExplanationLabel = UILabel()
     

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -29,6 +29,7 @@ final class WorkoutListViewController: UIViewController {
         register()
         setDelegate()
         setDraggable()
+        setTarget()
     }
     
     // MARK: - TableView Setting
@@ -117,5 +118,29 @@ extension WorkoutListViewController: UITableViewDragDelegate {
         } else {
             return [UIDragItem(itemProvider: NSItemProvider())]
         }
+    }
+}
+
+// MARK: - Screen Navigation
+
+private extension WorkoutListViewController {
+    func setTarget() {
+        let backButton = rootView.navigationBar.backButton
+        backButton.addTarget(self, action: #selector(backButtonDidTap), for: .touchUpInside)
+        
+        let startButton = rootView.startButton
+        startButton.addTarget(self, action: #selector(startButtonDidTap), for: .touchUpInside)
+    }
+    
+    @objc
+    func backButtonDidTap(_ sender: UIButton) {
+        navigationController?.popViewController(animated: true)
+    }
+    
+    @objc
+    private func startButtonDidTap(_ sender: UIButton) {
+        
+        // TODO: 스트레칭 화면으로 네비게이션 Push
+        
     }
 }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListNavigation.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListNavigation.swift
@@ -13,11 +13,11 @@ final class WorkoutListNavigation: UIView {
     
     // MARK: - UIComponent
     
+    let backButton = UIButton()
+    
     private let title = UILabel()
     
-    private lazy var backButton = UIButton()
-    
-    private lazy var shareButton = UIButton()
+    private let shareButton = UIButton()
     
     // MARK: - Initializer
     

--- a/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListView.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListView.swift
@@ -13,17 +13,17 @@ final class WorkoutListView: UIView {
     
     // MARK: - UIComponent
     
+    let navigationBar = WorkoutListNavigation()
+    
     let tableView = UITableView(frame: .zero, style: .plain)
     
-    private let navigationBar = WorkoutListNavigation()
+    let startButton = UIButton()
     
     private let header = WorkoutListHeader()
     
     private let footer = WorkoutListFooter()
     
     private let buttonBackGradiant = UIImageView()
-    
-    private lazy var startButton = UIButton()
 
     // MARK: - Initializer
     


### PR DESCRIPTION
## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - 홈 -> 운동리스트 화면 이동 구현

## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
상위 뷰컨트롤러(탭바)에서 화면 이동이 수행되어야 하기 때문에, 커스텀 델리게이트 패턴으로 구현하였습니다.
[핵심 코드는 이곳에..](https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-iOS/commit/27ec7900c98995c7445502028fb42cf9531bfe96)   
## Screenshot 📷
<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->

|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GIF | <img src = "https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-iOS/assets/91656206/21a71610-6fc5-4232-89b6-5a5e7fc0aa56" width ="250">|


## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
시작 버튼을 눌러 스트레칭 화면으로 이동할 수 있도록 메서드를 정의해 두었으며, TODO 주석을 남겨두었습니다. (@mmaybei) 

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #15