### PR TITLE
[Feat/#21] 추천 운동 리스트 화면 API 연결

### DIFF
--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -11,11 +11,24 @@ import SnapKit
 
 final class WorkoutListViewController: UIViewController {
     
+    // MARK: - WorkoutKind
+
+    private enum WorkoutKind {
+        case base(model: WorkoutListModel)
+        case additional(model: WorkoutListExercises)
+    }
+    
     // MARK: - Property
     
     private let rootView = WorkoutListView()
     
-    private var workoutList = WorkoutListModel.dummy()
+    private var workoutDataList: [WorkoutKind] = [] {
+        didSet {
+            DispatchQueue.main.async { [weak self] in
+                self?.rootView.tableView.reloadData()
+            }
+        }
+    }
     
     // MARK: - LifeCycle
     
@@ -30,6 +43,12 @@ final class WorkoutListViewController: UIViewController {
         setDelegate()
         setDraggable()
         setTarget()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        
+        fetch()
     }
     
     // MARK: - TableView Setting
@@ -48,6 +67,43 @@ final class WorkoutListViewController: UIViewController {
     private func setDraggable() {
         self.rootView.tableView.dragInteractionEnabled = true
         self.rootView.tableView.dragDelegate = self
+    }
+}
+
+// MARK: - Network
+
+private extension WorkoutListViewController {
+    
+    func fetch() {
+        WorkoutService.shared.request(for: .getWorkoutList) {
+            [weak self] response in switch response {
+            case .success(let responseModel):
+                guard let model = responseModel as? WorkoutListResponseModel else { return }
+                self?.configureList(workoutList: model.data)
+            case .requestErr:
+                print("요청 오류 입니다")
+            case .decodedErr:
+                print("디코딩 오류 입니다")
+            case .pathErr:
+                print("경로 오류 입니다")
+            case .serverErr:
+                print("서버 오류입니다")
+            case .networkFail:
+                print("네트워크 오류입니다")
+            }
+        }
+    }
+    
+    func configureList(workoutList: WorkoutList) {
+        var temp: [WorkoutKind] = [.base(model: .createDummy(for: .warmup))]
+        
+        for exercise in workoutList.exercises {
+            temp.append(.additional(model: exercise))
+        }
+        
+        temp.append(.base(model: .createDummy(for: .cooldown)))
+        
+        workoutDataList = temp
     }
 }
 
@@ -70,7 +126,7 @@ extension WorkoutListViewController: UITableViewDelegate {
 
 extension WorkoutListViewController: UITableViewDataSource {
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return workoutList.count
+        return workoutDataList.count
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -80,31 +136,36 @@ extension WorkoutListViewController: UITableViewDataSource {
             return UITableViewCell()
         }
         cell.selectionStyle = .none
-        cell.dataBind(workoutList[indexPath.row])
         
-        if indexPath.row == 0 || indexPath.row == workoutList.count - 1 {
+        let kind = workoutDataList[indexPath.row]
+        
+        switch kind {
+        case .base(let model):
+            cell.dataBind(model)
             cell.hideHamburgerButton()
+        case .additional(let model):
+            cell.dataBind(model)
         }
         
         return cell
     }
     
     func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        return indexPath.row != 0 && indexPath.row != workoutList.count - 1
+        return indexPath.row != 0 && indexPath.row != workoutDataList.count - 1
     }
     
     func tableView(_ tableView: UITableView, targetIndexPathForMoveFromRowAt sourceIndexPath: IndexPath, 
                    toProposedIndexPath proposedDestinationIndexPath: IndexPath) -> IndexPath {
-        if proposedDestinationIndexPath.row == 0 || proposedDestinationIndexPath.row == workoutList.count - 1 {
+        if proposedDestinationIndexPath.row == 0 || proposedDestinationIndexPath.row == workoutDataList.count - 1 {
             return sourceIndexPath
         }
         return proposedDestinationIndexPath
     }
     
     func tableView(_ tableView: UITableView, moveRowAt sourceIndexPath: IndexPath, to destinationIndexPath: IndexPath) {
-        let moveCell = self.workoutList[sourceIndexPath.row]
-        self.workoutList.remove(at: sourceIndexPath.row)
-        self.workoutList.insert(moveCell, at: destinationIndexPath.row)
+        let moveCell = self.workoutDataList[sourceIndexPath.row]
+        self.workoutDataList.remove(at: sourceIndexPath.row)
+        self.workoutDataList.insert(moveCell, at: destinationIndexPath.row)
     }
 }
 
@@ -113,7 +174,7 @@ extension WorkoutListViewController: UITableViewDataSource {
 extension WorkoutListViewController: UITableViewDragDelegate {
     func tableView(_ tableView: UITableView, itemsForBeginning session: UIDragSession, at indexPath: IndexPath)
     -> [UIDragItem] {
-        if indexPath.row == 0 || indexPath.row == workoutList.count - 1 {
+        if indexPath.row == 0 || indexPath.row == workoutDataList.count - 1 {
             return []
         } else {
             return [UIDragItem(itemProvider: NSItemProvider())]

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -47,6 +47,7 @@ final class WorkoutListViewController: UIViewController {
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+        navigationController?.navigationBar.isHidden = true
         
         fetch()
     }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -233,6 +233,7 @@ private extension WorkoutListViewController {
     @objc
     private func startButtonDidTap(_ sender: UIButton) {
         let viewController = WarmUpViewController()
+        navigationController?.navigationBar.isHidden = false
         navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -76,8 +76,8 @@ final class WorkoutListViewController: UIViewController {
 private extension WorkoutListViewController {
     
     func fetch() {
-        WorkoutService.shared.request(for: .getWorkoutList) {
-            [weak self] response in switch response {
+        WorkoutService.shared.request(for: .getWorkoutList) { [weak self] response in
+            switch response {
             case .success(let responseModel):
                 guard let model = responseModel as? WorkoutListResponseModel else { return }
                 self?.configureList(workoutList: model.data)
@@ -108,14 +108,14 @@ private extension WorkoutListViewController {
     }
     
     func update() {
-        var updateExercises: [Exercises] = []
+        var exercises: [Exercises] = []
         
         for case let .additional(model) in workoutDataList {
-            let exercise = Exercises(id: model.id, index: updateExercises.count)
-            updateExercises.append(exercise)
+            let exercise = Exercises(id: model.id, index: exercises.count)
+            exercises.append(exercise)
         }
         
-        let requestModel = WorkoutListRequestModel(exercises: updateExercises)
+        let requestModel = WorkoutListRequestModel(exercises: exercises)
         
         WorkoutService.shared.request(for: .changeWorkoutList(request: requestModel)) { result in
             switch result {

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -232,8 +232,7 @@ private extension WorkoutListViewController {
     
     @objc
     private func startButtonDidTap(_ sender: UIButton) {
-        
-        // TODO: 스트레칭 화면으로 네비게이션 Push
-        
+        let viewController = WarmUpViewController()
+        navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Controller/WorkoutListViewController.swift
@@ -105,6 +105,35 @@ private extension WorkoutListViewController {
         
         workoutDataList = temp
     }
+    
+    func update() {
+        var updateExercises: [Exercises] = []
+        
+        for case let .additional(model) in workoutDataList {
+            let exercise = Exercises(id: model.id, index: updateExercises.count)
+            updateExercises.append(exercise)
+        }
+        
+        let requestModel = WorkoutListRequestModel(exercises: updateExercises)
+        
+        WorkoutService.shared.request(for: .changeWorkoutList(request: requestModel)) { result in
+            switch result {
+            case .success(let responseModel):
+                guard let model = responseModel as? WorkoutListResponseModel else { return }
+                print(model)
+            case .requestErr:
+                print("요청 오류 입니다")
+            case .decodedErr:
+                print("디코딩 오류 입니다")
+            case .pathErr:
+                print("경로 오류 입니다")
+            case .serverErr:
+                print("서버 오류입니다")
+            case .networkFail:
+                print("네트워크 오류입니다")
+            }
+        }
+    }
 }
 
 // MARK: - UITableViewDelegate
@@ -145,6 +174,7 @@ extension WorkoutListViewController: UITableViewDataSource {
             cell.hideHamburgerButton()
         case .additional(let model):
             cell.dataBind(model)
+            cell.showHamburgerButton()
         }
         
         return cell
@@ -166,6 +196,8 @@ extension WorkoutListViewController: UITableViewDataSource {
         let moveCell = self.workoutDataList[sourceIndexPath.row]
         self.workoutDataList.remove(at: sourceIndexPath.row)
         self.workoutDataList.insert(moveCell, at: destinationIndexPath.row)
+        
+        update()
     }
 }
 

--- a/PlanFit/PlanFit/Presentation/WorkoutList/Model/WorkoutListModel.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/Model/WorkoutListModel.swift
@@ -16,59 +16,38 @@ struct WorkoutListModel {
 }
 
 extension WorkoutListModel {
-    static func dummy() -> [WorkoutListModel] {
-        return [
-            WorkoutListModel(
-                name: "웜업 스트레칭",
-                workoutImage: .stretching,
-                caption: "6개의 스트레칭",
-                arrowImage: .arrowDown,
-                additionalInfo:
-                    "싸이클\n로테이팅 허리 스트레칭\n후면 어깨 스트레칭\n어깨/등 스트레칭\n원 암 가슴 스트레칭\n크로스오버 힙/고관절 스트레칭"
-            ),
-            WorkoutListModel(
-                name: "렛 풀다운",
-                workoutImage: .latpulldown,
-                caption: "4세트 X 8.0kg X 15회",
-                arrowImage: .ellipsis,
-                additionalInfo: nil
-            ),
-            WorkoutListModel(
-                name: "체스트 프레스 머신",
-                workoutImage: .chestpress,
-                caption: "4세트 X 8.0kg X 15회",
-                arrowImage: .ellipsis,
-                additionalInfo: nil
-            ),
-            WorkoutListModel(
-                name: "덤벨 레터럴 레이즈",
-                workoutImage: .dumbellraise,
-                caption: "4세트 X 1.0kg X 15회",
-                arrowImage: .ellipsis,
-                additionalInfo: nil
-            ),
-            WorkoutListModel(
-                name: "덤벨 런치",
-                workoutImage: .dumbelllunge,
-                caption: "4세트 X 1.0kg X 15회",
-                arrowImage: .ellipsis,
-                additionalInfo: nil
-            ),
-            WorkoutListModel(
-                name: "덤벨 바이셉 컬",
-                workoutImage: .dumbellcurl,
-                caption: "4세트 X 1.0kg X 15회",
-                arrowImage: .ellipsis,
-                additionalInfo: nil
-            ),
-            WorkoutListModel(
-                name: "쿨다운 스트레칭",
-                workoutImage: .stretching,
-                caption: "4개의 스트레칭",
-                arrowImage: .arrowDown,
-                additionalInfo:
-                    "후면 어깨 스트레칭\n오버헤드 등 스트레칭\n비하인드 암 가슴 스트레칭\n스탠딩 힙/고관절 스트레칭\n"
-            )
-        ]
+    static func createDummy(for kind: DummyKind) -> WorkoutListModel {
+        return kind.dummy
+    }
+}
+
+extension WorkoutListModel {
+    enum DummyKind {
+        case warmup
+        case cooldown
+        
+        var dummy: WorkoutListModel {
+            switch self {
+            case .warmup:
+                WorkoutListModel(
+                    name: "웜업 스트레칭",
+                    workoutImage: .stretching,
+                    caption: "6개의 스트레칭",
+                    arrowImage: .arrowDown,
+                    additionalInfo:
+                        "싸이클\n로테이팅 허리 스트레칭\n후면 어깨 스트레칭\n어깨/등 스트레칭\n원 암 가슴 스트레칭\n크로스오버 힙/고관절 스트레칭"
+                )
+                
+            case .cooldown:
+                WorkoutListModel(
+                    name: "쿨다운 스트레칭",
+                    workoutImage: .stretching,
+                    caption: "4개의 스트레칭",
+                    arrowImage: .arrowDown,
+                    additionalInfo:
+                        "후면 어깨 스트레칭\n오버헤드 등 스트레칭\n비하인드 암 가슴 스트레칭\n스탠딩 힙/고관절 스트레칭\n"
+                )
+            }
+        }
     }
 }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListViewCell.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListViewCell.swift
@@ -137,7 +137,6 @@ private extension WorkoutListViewCell {
         }
         additionalInfoLabel.snp.makeConstraints {
             $0.top.equalToSuperview().offset(88)
-            //$0.bottom.lessThanOrEqualToSuperview().offset(-8)
             $0.bottom.equalToSuperview().offset(-8).priority(.low)
             $0.leading.equalToSuperview().offset(124)
         }
@@ -152,11 +151,29 @@ private extension WorkoutListViewCell {
 // MARK: - Data Bind
 
 extension WorkoutListViewCell {
-    func dataBind (_ data: WorkoutListModel) {
+    func dataBind(_ data: WorkoutListModel) {
         nameLabel.text = data.name
         workoutImage.image = data.workoutImage
         captionLabel.text = data.caption
         arrowButton.setImage(data.arrowImage, for: .normal)
         additionalInfoLabel.text = data.additionalInfo
+    }
+    
+    func dataBind(_ data: WorkoutListExercises) {
+        nameLabel.text = data.name
+        workoutImage.image = configureImage(from: data.id)
+        captionLabel.text = "\(data.set)세트 X \(data.weight)kg X \(data.count)회"
+        arrowButton.setImage(.ellipsis, for: .normal)
+    }
+    
+    private func configureImage(from id: Int) -> UIImage {
+        switch id {
+        case 1: return .latpulldown
+        case 2: return .chestpress
+        case 3: return .dumbellraise
+        case 4: return .dumbelllunge
+        case 5: return .dumbellcurl
+        default: return .stretching
+        }
     }
 }

--- a/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListViewCell.swift
+++ b/PlanFit/PlanFit/Presentation/WorkoutList/View/WorkoutListViewCell.swift
@@ -66,6 +66,10 @@ final class WorkoutListViewCell: UITableViewCell, ReuseIdentifiable {
         hamburgerButton.isHidden = true
     }
     
+    func showHamburgerButton() {
+        hamburgerButton.isHidden = false
+    }
+    
     @objc
     private func arrowButtonDidTap() {
         updateForExpansion()


### PR DESCRIPTION
## What is the PR? 🔍
<!-- 아래 리스트를 지우고, 작업하게 된 배경을 적어주세요. -->
 - moya 네트워크 연결
 - 화면 이동 구현

## Changes 📝
<!-- 작업 내용 및 덧붙이고 싶은 내용이 있다면! -->
 - 추천 운동 리스트 GET API 연결
 - 순서 변경 PUT API 연결
 - 운동 리스트 화면에서 스트레칭 화면 이동 구현

## Screenshot 📷

<!-- 작업한 화면이 있다면 스크린 샷으로 첨부해주세요. -->
|    기능    |   스크린샷   |
| :-------------: | :----------: |
| GET | <img src = "https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-iOS/assets/144984293/042533b2-afab-4e9a-ab8c-172e24496226" width ="250">|
| PUT | <img src = "https://github.com/NOW-SOPT-APP3-PlanFit/PlanFit-iOS/assets/144984293/c0b16d71-e8c2-406c-af8b-a15a65e4a510" width ="250">|

## To Reviewers 🙏
<!-- 리뷰어에게 주목했으면 하는 점 or 바라는 점을 적어주세요. -->
<details>
<summary>WorkoutKind</summary>

```swift
private enum WorkoutKind {
        case base(model: WorkoutListModel)
        case additional(model: WorkoutListExercises)
 }
```
</details>

첫 번째 셀과 마지막 셀을 `base`로, 나머지 셀들을 `additional`로 관리합니다! `base`는 기존 목업 데이터를, `additonal`은 서버로 부터 받은 데이터를 가집니다. 

<details>
<summary>configureList()</summary>

```swift
func configureList(workoutList: WorkoutList) {
        var temp: [WorkoutKind] = [.base(model: .createDummy(for: .warmup))]
        
        for exercise in workoutList.exercises {
            temp.append(.additional(model: exercise))
        }
        
        temp.append(.base(model: .createDummy(for: .cooldown)))
        
        workoutDataList = temp
}
```
</details>

`configureList()` 함수를 통해 두 케이스를 합한 새로운 배열 `workoutDataList`를 생성합니다.

## Related Issues 💭
<!-- 작업한 이슈번호를 # 뒤에 붙여주세요. 수고했습니다~* -->
- Resolved: #21